### PR TITLE
ensure icon_path is a str

### DIFF
--- a/jupyter_shiny_proxy/__init__.py
+++ b/jupyter_shiny_proxy/__init__.py
@@ -70,7 +70,7 @@ def setup_shiny():
         "command": _get_shiny_cmd,
         "launcher_entry": {
             "title": "Shiny",
-            "icon_path": get_icon_path(),
+            "icon_path": str(get_icon_path()),
             "timeout": shiny_config.timeout,
         },
     }


### PR DESCRIPTION
fixes #7 

shiny-proxy can't start now that jupyter-server-proxy has started validating traits, and icon_path is required to be a string.